### PR TITLE
Improve FoodTruck bottom sheet details

### DIFF
--- a/app/src/main/java/com/redfin/redfin/foodtrucks/presentation/details/FoodTruckDetailBottomSheet.kt
+++ b/app/src/main/java/com/redfin/redfin/foodtrucks/presentation/details/FoodTruckDetailBottomSheet.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
+import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
@@ -32,15 +33,39 @@ fun FoodTruckDetailBottomSheet(
                 .padding(horizontal = 16.dp, vertical = 8.dp)
         ) {
             Column(modifier = Modifier.padding(16.dp)) {
-                Text(text = foodTruck.name.orEmpty(), style = MaterialTheme.typography.titleLarge)
+                Text(
+                    text = foodTruck.name.orEmpty(),
+                    style = MaterialTheme.typography.titleLarge
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(R.string.address_label, foodTruck.address.orEmpty()),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = foodTruck.description.orEmpty(),
+                    style = MaterialTheme.typography.bodySmall
+                )
                 Spacer(modifier = Modifier.height(8.dp))
-                Text(text = foodTruck.address.orEmpty(), style = MaterialTheme.typography.bodyMedium)
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(text = foodTruck.description.orEmpty(), style = MaterialTheme.typography.bodySmall)
+                Divider()
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(
-                    text = stringResource(R.string.open_hours, foodTruck.startTime.orEmpty(), foodTruck.endTime.orEmpty()),
-                    style = MaterialTheme.typography.labelMedium
+                    text = stringResource(
+                        R.string.open_hours,
+                        foodTruck.startTime.orEmpty(),
+                        foodTruck.endTime.orEmpty()
+                    ),
+                    style = MaterialTheme.typography.labelLarge
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(
+                        R.string.coordinates,
+                        foodTruck.latitude.orEmpty(),
+                        foodTruck.longitude.orEmpty()
+                    ),
+                    style = MaterialTheme.typography.labelSmall
                 )
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,5 +2,7 @@
     <string name="app_name">RedFin</string>
 
     <string name="open_hours">Open: %1$s - %2$s</string>
+    <string name="coordinates">Coordinates: %1$s, %2$s</string>
+    <string name="address_label">Address: %1$s</string>
     <string name="error_loading_food_trucks">Error loading food trucks</string>
 </resources>


### PR DESCRIPTION
## Summary
- show address, coordinates and add styling divider in FoodTruckDetailBottomSheet
- add supporting string resources

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e61baae483238fe4fff07b7db32c