### PR TITLE
Implement navigation drawer

### DIFF
--- a/app/src/main/java/com/redfin/redfin/MainActivity.kt
+++ b/app/src/main/java/com/redfin/redfin/MainActivity.kt
@@ -7,14 +7,23 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.rememberDrawerState
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.NavigationDrawerItemDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -22,8 +31,10 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.redfin.redfin.foodtrucks.presentation.list.mvi_example.FoodTrucksMVIListScreen
 import com.redfin.redfin.foodtrucks.presentation.map.FoodTrucksMapScreen
+import com.redfin.redfin.settings.SettingsScreen
 import com.redfin.redfin.ui.theme.RedFinTheme
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -33,25 +44,70 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             RedFinTheme {
+                val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
+                val scope = rememberCoroutineScope()
                 val navController = rememberNavController()
                 val navBackStackEntry by navController.currentBackStackEntryAsState()
                 val currentRoute = navBackStackEntry?.destination?.route
-                Scaffold(
-                    topBar = { TopAppBar(title = { Text("Food Trucks") }) },
-                    floatingActionButton = {
-                        if (currentRoute != "map") {
-                            FloatingActionButton(
-                                onClick = { navController.navigate("map") }
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.LocationOn,
-                                    contentDescription = "Open Map"
-                                )
-                            }
+
+                ModalNavigationDrawer(
+                    drawerState = drawerState,
+                    drawerContent = {
+                        ModalDrawerSheet {
+                            NavigationDrawerItem(
+                                label = { Text("List") },
+                                selected = currentRoute == "list",
+                                onClick = {
+                                    navController.navigate("list") { launchSingleTop = true }
+                                    scope.launch { drawerState.close() }
+                                },
+                                modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding)
+                            )
+                            NavigationDrawerItem(
+                                label = { Text("Map") },
+                                selected = currentRoute == "map",
+                                onClick = {
+                                    navController.navigate("map") { launchSingleTop = true }
+                                    scope.launch { drawerState.close() }
+                                },
+                                modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding)
+                            )
+                            NavigationDrawerItem(
+                                label = { Text("Settings") },
+                                selected = currentRoute == "settings",
+                                onClick = {
+                                    navController.navigate("settings") { launchSingleTop = true }
+                                    scope.launch { drawerState.close() }
+                                },
+                                modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding)
+                            )
                         }
                     }
-                ) { innerPadding ->
-                    NavigationHost(navController = navController, modifier = Modifier.padding(innerPadding))
+                ) {
+                    Scaffold(
+                        topBar = {
+                            TopAppBar(
+                                title = { Text("Food Trucks") },
+                                navigationIcon = {
+                                    IconButton(onClick = { scope.launch { drawerState.open() } }) {
+                                        Icon(imageVector = Icons.Default.Menu, contentDescription = "Menu")
+                                    }
+                                }
+                            )
+                        },
+                        floatingActionButton = {
+                            if (currentRoute != "map") {
+                                FloatingActionButton(onClick = { navController.navigate("map") }) {
+                                    Icon(
+                                        imageVector = Icons.Default.LocationOn,
+                                        contentDescription = "Open Map"
+                                    )
+                                }
+                            }
+                        }
+                    ) { innerPadding ->
+                        NavigationHost(navController = navController, modifier = Modifier.padding(innerPadding))
+                    }
                 }
             }
         }
@@ -66,6 +122,9 @@ fun NavigationHost(navController: androidx.navigation.NavHostController, modifie
         }
         composable("map") {
             FoodTrucksMapScreen()
+        }
+        composable("settings") {
+             SettingsScreen()
         }
     }
 }

--- a/app/src/main/java/com/redfin/redfin/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/redfin/redfin/settings/SettingsScreen.kt
@@ -1,0 +1,16 @@
+package com.redfin.redfin.settings
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun SettingsScreen() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(text = "Settings", style = MaterialTheme.typography.headlineSmall)
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple Settings screen
- implement `ModalNavigationDrawer` with 3 navigation items
- include new `settings` destination

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f7dbb3b08323914648c7a513cb2b